### PR TITLE
Fix various typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ if (NOT GKICK_ARCHITECTURE)
 endif ()
 
 if (GKICK_ARCHITECTURE MATCHES x86_64)
-  message(STATUS "set optimisation complier flags for ${GKICK_ARCHITECTURE}")
+  message(STATUS "set optimisation compiler flags for ${GKICK_ARCHITECTURE}")
   set(GKICK_OPTIMISATION_FLAGS "-O3 -msse -msse2 -mfpmath=sse -ffast-math -fomit-frame-pointer")
 else ()
-  message(STATUS "set optimisation complier flags for ${GKICK_ARCHITECTURE}")
+  message(STATUS "set optimisation compiler flags for ${GKICK_ARCHITECTURE}")
   set(GKICK_OPTIMISATION_FLAGS "-O3 -ffast-math -fomit-frame-pointer")
 endif ()
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -195,7 +195,7 @@ Updating to this version must be backward compatible.
 
 #### Fixes
 
-   - fix compliers flags
+   - fix compilers flags
 
 ### Changes from 2.2.1 to 2.2.2
 

--- a/data/design/geonkick.svg
+++ b/data/design/geonkick.svg
@@ -8474,7 +8474,7 @@
            id="tspan10103-9-1-1-1-0"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Sqare</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Square</tspan></text>
     </g>
     <g
        transform="matrix(0.02199185,0,0,0.02199185,176.31137,139.29584)"
@@ -8872,7 +8872,7 @@
            id="tspan10103-9-1-1-1-04"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Sqare</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Square</tspan></text>
     </g>
     <g
        transform="matrix(0.02198968,0,0,0.02588201,192.43125,154.09101)"
@@ -9525,7 +9525,7 @@
              y="417.70291"
              x="113.74126"
              id="tspan10103-9-9-5-5-7-9-9-6"
-             sodipodi:role="line">Hight Pass</tspan></text>
+             sodipodi:role="line">High Pass</tspan></text>
       </g>
       <ellipse
          transform="matrix(0.21214568,0,0,0.21214568,310.7392,365.17018)"
@@ -9745,7 +9745,7 @@
              y="417.70291"
              x="113.74126"
              id="tspan10103-9-9-5-5-7-9-9-9"
-             sodipodi:role="line">Hight Pass</tspan></text>
+             sodipodi:role="line">High Pass</tspan></text>
       </g>
       <ellipse
          transform="matrix(0.21214568,0,0,0.21214568,310.7392,365.17018)"
@@ -10060,7 +10060,7 @@
            id="tspan10103-9-1-1-1-0-7"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Sqare</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Square</tspan></text>
     </g>
     <g
        transform="matrix(0.02199185,0,0,0.02199185,160.77822,139.27918)"
@@ -10557,7 +10557,7 @@
            id="tspan10103-9-9-5-5-7-9-9-6-0"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">Hight Pass</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">High Pass</tspan></text>
       <ellipse
          transform="matrix(0.21214568,0,0,0.21214568,310.7392,365.17018)"
          ry="4.4376335"
@@ -11061,7 +11061,7 @@
            y="417.70291"
            x="113.74126"
            id="tspan10103-9-1-9-08-8-4-3-3"
-           sodipodi:role="line">Hight Pass</tspan></text>
+           sodipodi:role="line">High Pass</tspan></text>
     </g>
     <g
        transform="matrix(0.24621447,0,0,0.24621447,75.824914,118.81173)"
@@ -17075,7 +17075,7 @@
            id="tspan8902-5-5"
            x="598.14697"
            y="123.13248"
-           style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Legth,  825 ms</tspan></text>
+           style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Length,  825 ms</tspan></text>
     </g>
     <g
        transform="matrix(0.40752535,0,0,0.40752535,188.19924,80.273752)"
@@ -21858,7 +21858,7 @@
            y="417.70291"
            x="113.74126"
            id="tspan10103-9-1-1-1-0-9"
-           sodipodi:role="line">Sqare</tspan></text>
+           sodipodi:role="line">Square</tspan></text>
     </g>
     <g
        style="display:inline"
@@ -22545,7 +22545,7 @@
            y="417.70291"
            x="113.74126"
            id="tspan10103-9-1-1-1-04-4"
-           sodipodi:role="line">Sqare</tspan></text>
+           sodipodi:role="line">Square</tspan></text>
     </g>
     <g
        style="display:inline"
@@ -23044,7 +23044,7 @@
              id="tspan10103-9-9-5-5-7-9-5"
              x="113.74126"
              y="417.70291"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">Hight Pass</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">High Pass</tspan></text>
       </g>
       <ellipse
          style="opacity:0.91500005;fill:#77bb80;fill-opacity:1;stroke:none;stroke-width:0.84206176;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter16738-4-3-6-2-8)"
@@ -23755,7 +23755,7 @@
              id="tspan10103-9-9-5-5-7-9-9-6-2"
              x="113.74126"
              y="417.70291"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">Hight Pass</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">High Pass</tspan></text>
       </g>
       <ellipse
          style="opacity:0.91500005;fill:#77bb80;fill-opacity:1;stroke:none;stroke-width:0.84206176;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter16738-4-3-6-2-8-3-33)"
@@ -23975,7 +23975,7 @@
              id="tspan10103-9-9-5-5-7-9-9-9-6"
              x="113.74126"
              y="417.70291"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">Hight Pass</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#ffffff;fill-opacity:1;stroke-width:3.13520145;stroke-miterlimit:4;stroke-dasharray:none">High Pass</tspan></text>
       </g>
       <ellipse
          style="opacity:0.91500005;fill:#77bb80;fill-opacity:1;stroke:none;stroke-width:0.84206176;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter16738-4-3-6-2-8-5-2)"
@@ -24291,7 +24291,7 @@
            y="417.70291"
            x="113.74126"
            id="tspan10103-9-1-1-1-0-7-3"
-           sodipodi:role="line">Sqare</tspan></text>
+           sodipodi:role="line">Square</tspan></text>
     </g>
     <g
        style="display:inline"
@@ -24788,7 +24788,7 @@
            y="417.70291"
            x="113.74126"
            id="tspan10103-9-9-5-5-7-9-9-6-0-0"
-           sodipodi:role="line">Hight Pass</tspan></text>
+           sodipodi:role="line">High Pass</tspan></text>
       <ellipse
          style="opacity:0.91500005;fill:#77bb80;fill-opacity:1;stroke:none;stroke-width:0.84206176;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter16738-4-3-6-2-8-3-3-7)"
          id="path10686-5-1-5-6-7-9-6-4-4-5"
@@ -25349,7 +25349,7 @@
            id="tspan10103-9-1-9-08-8-4-3-3-4"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#edffff;fill-opacity:1;stroke-width:0.41765422">Hight Pass</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#edffff;fill-opacity:1;stroke-width:0.41765422">High Pass</tspan></text>
     </g>
     <g
        style="display:inline"
@@ -28750,7 +28750,7 @@
            id="tspan10103-9-1-1-1-0-6"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Sqare</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Square</tspan></text>
     </g>
     <g
        style="display:inline"
@@ -29062,7 +29062,7 @@
            id="tspan10103-9-1-1-1-0-7-2"
            x="113.74126"
            y="417.70291"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Sqare</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.63982773px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L';fill:#8b8f74;fill-opacity:1;stroke-width:0.41765422">Square</tspan></text>
     </g>
     <g
        transform="matrix(0.07431999,0,0,0.07431999,228.17678,467.47971)"
@@ -29603,7 +29603,7 @@
            id="tspan8902-5-5-5"
            x="598.14697"
            y="123.13248"
-           style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Legth,  825 ms</tspan></text>
+           style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Length,  825 ms</tspan></text>
     </g>
     <text
        inkscape:export-ydpi="164.11937"

--- a/data/design/geonkick_2.svg
+++ b/data/design/geonkick_2.svg
@@ -734,7 +734,7 @@
          id="tspan8902-5-5"
          x="598.14697"
          y="123.13248"
-         style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Legth,  825 ms</tspan></text>
+         style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Length,  825 ms</tspan></text>
   </g>
   <text
      xml:space="preserve"

--- a/data/design/geonkick_new.svg
+++ b/data/design/geonkick_new.svg
@@ -827,7 +827,7 @@
            id="tspan8902-5-5"
            x="598.14697"
            y="123.13248"
-           style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Legth,  825 ms</tspan></text>
+           style="fill:#969898;fill-opacity:1;stroke-width:0.08815636">Length,  825 ms</tspan></text>
     </g>
     <text
        xml:space="preserve"

--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -79,7 +79,7 @@ percussion from the kit list and modify it.
 
 A percussion consists of 3 layers that can be turned on/off with the
 buttons "L1", "L2" and "L3" from the top bar menu. Every layer contains
-the 2 oscillators and the noise generator. The sum of thee layers are passed
+the 2 oscillators and the noise generator. The sum of these layers are passed
 to general controls. The contribution of every layer to the output can
 be controlled by the "Layers Mixer". There is only one controllable layer
 by the UI but the user can switch the layer by pressing the button
@@ -114,7 +114,7 @@ and save percussion preset, export percussion.
    - "Tune" - checkbox will turn on/off tuning of the current percussion.
    - Preset label - it shows the name of the current selected percussion,
      by default shows "Default".
-   - "Contorls", "Kit", "Presets" and "Samples" is submenu that will switch to controls, kit, preset and sample browser UI
+   - "Controls", "Kit", "Presets" and "Samples" is submenu that will switch to controls, kit, preset and sample browser UI
 
 #### Shortcut Keys
 
@@ -201,7 +201,7 @@ are grouped and arranged vertically.
      move the start of the sample up to 1/2 of the percussion length
    - Amplitude knob - sets the maximum current amplitude of the oscillator
    - Frequency knob - sets the maximum current frequency of the oscillator
-   - Pitch kbob - will set the pitch shift range when the wave funciton of the oscillator is set as sample
+   - Pitch kbob - will set the pitch shift range when the wave function of the oscillator is set as sample
    -  pitch buttons will show the evelopes. 
    - "Filter" button will enable/disable filter for the oscillator
    - Oscillator envelopes for amplitude, frequency, pitch shift, filter cutoff can be accessed with buttons
@@ -227,7 +227,7 @@ and applied from top to bottom. The compressor is applied the last one.
 - "Amplitude" buttons shows the general amplitude envelope
 - Filter (the sample controls as for oscillator)
 - Distortion
-- Distortion drive and volume envelopes can be accesed with buttons "Drive" and "Volume"
+- Distortion drive and volume envelopes can be accessed with buttons "Drive" and "Volume"
 - Compressor
 
 #### Limiter
@@ -250,7 +250,7 @@ noise generator and after layers mixer, i.e. general filter.
 
 Here are the parameters:
 
-  - "Filter" - buttons that enable/disale filter
+  - "Filter" - buttons that enable/disable filter
   - Cutoff knob - controls the cutoff frequency of the filter, the range is logarithmic (20Hz - 20kHz).
   - "Cutoff" - the button the will show the cutoff envelope
   - Resonance "Q". The knob is logarithmic ranging from 0.01 to 10.

--- a/dsp/src/audio_output.c
+++ b/dsp/src/audio_output.c
@@ -189,7 +189,7 @@ void gkick_audio_output_swap_buffers(struct gkick_audio_output *audio_output)
         gkick_buffer_reset((struct gkick_buffer*)audio_output->playing_buffer);
 
         /**
-         * Try lock. If succesfull, swap buffers. If not, continue with
+         * Try lock. If successful, swap buffers. If not, continue with
          * the current one to play until the next press of the key.
          */
         if (pthread_mutex_trylock(&audio_output->lock) == 0) {

--- a/dsp/src/audio_output.h
+++ b/dsp/src/audio_output.h
@@ -33,7 +33,7 @@
  * is an interface to an array that holds the synthesised percussion.
  * Is has nothing to do with any real audio interfaces.
  * It provides access to the samples from the array in a "playable mode",
- * i.e. in a state machine fasion.
+ * i.e. in a state machine fashion.
  */
 
 /* Decay time measured in number of audio frames. */
@@ -72,7 +72,7 @@ struct gkick_audio_output
 
         /**
          * Triggers the audio thread to start to play
-         * the precussion with the maximum key velocity.
+         * the percussion with the maximum key velocity.
          */
         _Atomic bool play;
 

--- a/dsp/src/envelope.c
+++ b/dsp/src/envelope.c
@@ -121,7 +121,7 @@ void gkick_envelope_add_sorted(struct gkick_envelope *envelope,
 	        point->prev = envelope->last;
 		envelope->last = point;
 	} else if (point->x <= envelope->first->x) {
-                /* Add as a frist element. */
+                /* Add as a first element. */
 		envelope->first->prev = point;
 	        point->next = envelope->first;
 		envelope->first = point;

--- a/dsp/src/geonkick.c
+++ b/dsp/src/geonkick.c
@@ -422,7 +422,7 @@ geonkick_kick_set_amplitude(struct geonkick *kick,
                             gkick_real amplitude)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -438,7 +438,7 @@ geonkick_kick_get_amplitude(struct geonkick *kick,
                             gkick_real *amplitude)
 {
         if (kick == NULL || amplitude == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_kick_get_amplitude(kick->synths[kick->per_index], amplitude);
@@ -449,7 +449,7 @@ geonkick_kick_set_filter_frequency(struct geonkick *kick,
                                    gkick_real frequency)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -465,7 +465,7 @@ geonkick_kick_filter_enable(struct geonkick *kick,
                             int enable)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -481,7 +481,7 @@ geonkick_kick_filter_is_enabled(struct geonkick *kick,
                                 int *enabled)
 {
         if (kick == NULL || enabled == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return geonkick_synth_kick_filter_is_enabled(kick->synths[kick->per_index],
@@ -493,7 +493,7 @@ geonkick_kick_get_filter_frequency(struct geonkick *kick,
                                    gkick_real *frequency)
 {
         if (kick == NULL || frequency == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_kick_get_filter_frequency(kick->synths[kick->per_index],
@@ -505,7 +505,7 @@ geonkick_kick_set_filter_factor(struct geonkick *kick,
                                 gkick_real factor)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -520,7 +520,7 @@ geonkick_kick_get_filter_factor(struct geonkick *kick,
                                 gkick_real *factor)
 {
         if (kick == NULL || factor == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_kick_get_filter_factor(kick->synths[kick->per_index], factor);
@@ -531,7 +531,7 @@ geonkick_set_kick_filter_type(struct geonkick *kick,
                               enum gkick_filter_type type)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -546,7 +546,7 @@ geonkick_get_kick_filter_type(struct geonkick *kick,
                               enum gkick_filter_type *type)
 {
         if (kick == NULL || type == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_get_kick_filter_type(kick->synths[kick->per_index], type);
@@ -559,7 +559,7 @@ geonkick_kick_envelope_get_points(struct geonkick *kick,
                                   size_t *npoints)
 {
         if (kick == NULL || buf == NULL || npoints == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_kick_envelope_get_points(kick->synths[kick->per_index],
@@ -594,7 +594,7 @@ geonkick_kick_add_env_point(struct geonkick *kick,
                             gkick_real y)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -612,7 +612,7 @@ geonkick_kick_remove_env_point(struct geonkick *kick,
                                size_t index)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -632,7 +632,7 @@ geonkick_kick_update_env_point(struct geonkick *kick,
                                gkick_real y)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -741,7 +741,7 @@ enum geonkick_error
 geonkick_play(struct geonkick *kick, size_t id)
 {
         if (kick == NULL || id >= GEONKICK_MAX_PERCUSSIONS) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_audio_play(kick->audio, id);
@@ -754,7 +754,7 @@ geonkick_key_pressed(struct geonkick *kick,
                      int velocity)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_audio_key_pressed(kick->audio,
@@ -768,7 +768,7 @@ geonkick_get_kick_buffer_size(struct geonkick *kick, size_t *size)
 {
         enum geonkick_error res;
         if (kick  == NULL || size == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         res = gkick_synth_get_buffer_size(kick->synths[kick->per_index],
@@ -783,7 +783,7 @@ geonkick_get_kick_buffer(struct geonkick *kick,
 {
         enum geonkick_error res;
         if (kick  == NULL || buffer == NULL || size < 1) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         res = gkick_synth_get_buffer(kick->synths[kick->per_index],
@@ -801,7 +801,7 @@ geonkick_set_kick_buffer_callback(struct geonkick *kick,
                                   void *arg)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -822,7 +822,7 @@ geonkick_set_kick_limiter_callback(struct geonkick *kick,
                                    void *arg)
 {
         if (kick  == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_audio_set_limiter_callback(kick->audio,
@@ -835,7 +835,7 @@ geonkick_set_limiter_value(struct geonkick *kick,
                            gkick_real limit)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_audio_set_limiter_val(kick->audio,
@@ -848,7 +848,7 @@ geonkick_get_limiter_value(struct geonkick *kick,
                            gkick_real *limit)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_audio_get_limiter_val(kick->audio,
@@ -862,7 +862,7 @@ geonkick_set_osc_filter_type(struct geonkick *kick,
                              enum gkick_filter_type type)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -881,7 +881,7 @@ geonkick_get_osc_filter_type(struct geonkick *kick,
                              enum gkick_filter_type *type)
 {
         if (kick == NULL || type == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_get_osc_filter_type(kick->synths[kick->per_index],
@@ -895,7 +895,7 @@ geonkick_set_osc_filter_cutoff_freq(struct geonkick *kick,
                                     gkick_real cutoff)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -914,7 +914,7 @@ geonkick_get_osc_filter_cutoff_freq(struct geonkick *kick,
                                     gkick_real *cutoff)
 {
         if (kick == NULL || cutoff == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_get_osc_filter_cutoff(kick->synths[kick->per_index],
@@ -928,7 +928,7 @@ geonkick_set_osc_filter_factor(struct geonkick *kick,
                                gkick_real factor)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -946,7 +946,7 @@ geonkick_get_osc_filter_factor(struct geonkick *kick,
                                gkick_real *factor)
 {
         if (kick == NULL || factor == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_get_osc_filter_factor(kick->synths[kick->per_index],
@@ -961,7 +961,7 @@ geonkick_enbale_osc_filter(struct geonkick *kick,
                            int enable)
 {
         if (kick == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         enum geonkick_error res;
@@ -979,7 +979,7 @@ geonkick_osc_filter_is_enabled(struct geonkick *kick,
                                int *enable)
 {
         if (kick == NULL || enable == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         return gkick_synth_osc_is_enabled_filter(kick->synths[kick->per_index],
@@ -994,7 +994,7 @@ geonkick_get_sample_rate(struct geonkick *kick,
         GEONKICK_UNUSED(kick);
 
         if (sample_rate == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
         *sample_rate = kick->sample_rate;

--- a/dsp/src/gkick_audio.h
+++ b/dsp/src/gkick_audio.h
@@ -32,7 +32,7 @@ struct gkick_mixer;
 
 struct gkick_audio {
         int sample_rate;
-        /* Audio outputs. The last audio ouput is used as a sample preview. */
+        /* Audio outputs. The last audio output is used as a sample preview. */
         struct gkick_audio_output *audio_outputs[GEONKICK_MAX_PERCUSSIONS + 1];
 	struct gkick_mixer *mixer;
         struct gkick_jack *jack;

--- a/dsp/src/gkick_buffer.c
+++ b/dsp/src/gkick_buffer.c
@@ -27,7 +27,7 @@ void
 gkick_buffer_new(struct gkick_buffer **buffer, int size)
 {
         if (buffer == NULL || size < 1) {
-                gkick_log_error("wrong argumnets");
+                gkick_log_error("wrong arguments");
                 return;
         }
 

--- a/dsp/src/gkick_jack.c
+++ b/dsp/src/gkick_jack.c
@@ -293,7 +293,7 @@ gkick_jack_is_midi_in_enabled(struct gkick_jack *jack)
         int enabled;
 
         if (jack == NULL) {
-                gkick_log_error("wrong arugment");
+                gkick_log_error("wrong argument");
                 return 0;
         }
 

--- a/dsp/src/oscillator.c
+++ b/dsp/src/oscillator.c
@@ -160,7 +160,7 @@ gkick_real gkick_osc_value(struct gkick_oscillator *osc,
         gkick_real v;
         gkick_real env_x;
 
-        // Caluclate the x corrdinate between 0 and 1.0 for the envelope.
+        // Calculate the x coordinate between 0 and 1.0 for the envelope.
         env_x = t / kick_len;
         amp = osc->amplitude * gkick_envelope_get_value(osc->envelopes[GKICK_OSC_AMPLITUDE_ENVELOPE], env_x);
         v = 0.0f;

--- a/dsp/src/oscillator.h
+++ b/dsp/src/oscillator.h
@@ -37,7 +37,7 @@ enum geonkick_osc_state {
         GEONKICK_OSC_STATE_ENABLED  = 1
 };
 
-enum gkick_osc_nevelope_type {
+enum gkick_osc_envelope_type {
         GKICK_OSC_AMPLITUDE_ENVELOPE   = 0,
         GKICK_OSC_FREQUENCY_ENVELOPE   = 1,
         GKICK_OSC_PITCH_SHIFT_ENVELOPE = 2

--- a/dsp/src/presets_folder.h
+++ b/dsp/src/presets_folder.h
@@ -26,8 +26,8 @@
 clss Preset {
  public:
         class enum PresetType : int {
-            PrecussionPreset,
-            KitPresset
+            PercussionPreset,
+            KitPreset
         };
 
         explicit Preset(const std::filesystem::path path);

--- a/dsp/src/synthesizer.c
+++ b/dsp/src/synthesizer.c
@@ -1233,7 +1233,7 @@ gkick_synth_set_output(struct gkick_synth *synth,
                        struct gkick_audio_output *output)
 {
         if (synth == NULL || output == NULL) {
-                gkick_log_error("wrong arugment");
+                gkick_log_error("wrong argument");
                 return;
         }
         synth->output = output;
@@ -1393,7 +1393,7 @@ gkick_synth_set_osc_filter_type(struct gkick_synth *synth,
         enum geonkick_error res;
 
         if (synth == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1423,7 +1423,7 @@ gkick_synth_get_osc_filter_type(struct gkick_synth *synth,
                                 enum gkick_filter_type *type)
 {
         if (synth == NULL || type == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1449,7 +1449,7 @@ gkick_synth_set_osc_filter_cutoff(struct gkick_synth *synth,
                                   gkick_real cutoff)
 {
         if (synth == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1479,7 +1479,7 @@ gkick_synth_get_osc_filter_cutoff(struct gkick_synth *synth,
                                   gkick_real *cutoff)
 {
         if (synth == NULL || cutoff == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1504,7 +1504,7 @@ gkick_synth_set_osc_filter_factor(struct gkick_synth *synth,
                                gkick_real factor)
 {
         if (synth == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1534,7 +1534,7 @@ gkick_synth_get_osc_filter_factor(struct gkick_synth *synth,
                                gkick_real *factor)
 {
         if (synth == NULL || factor == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1560,7 +1560,7 @@ gkick_synth_osc_enable_filter(struct gkick_synth *synth,
                               int enable)
 {
         if (synth == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 
@@ -1589,7 +1589,7 @@ gkick_synth_osc_is_enabled_filter(struct gkick_synth *synth,
                                   int *enabled)
 {
         if (synth == NULL || enabled == NULL) {
-                gkick_log_error("wrong arugments");
+                gkick_log_error("wrong arguments");
                 return GEONKICK_ERROR;
         }
 

--- a/dsp/src/synthesizer.h
+++ b/dsp/src/synthesizer.h
@@ -74,8 +74,8 @@ struct gkick_synth {
         atomic_bool buffer_update;
 
         /**
-         * Kick smaples buffer where the synthesizer is doing the synthesis.
-         * It is swaped with one of the oudio output buffers atomically.
+         * Kick samples buffer where the synthesizer is doing the synthesis.
+         * It is swapped with one of the oudio output buffers atomically.
          */
         char* _Atomic buffer;
         /* Kick buffer size. */
@@ -87,7 +87,7 @@ struct gkick_synth {
         struct gkick_audio_output *output;
 
         /**
-         * Pointer to a funtion to be
+         * Pointer to a function to be
          * called when the synth has finished the synthesis.
          */
         void (*buffer_callback) (void*, gkick_real *buff,

--- a/dsp/src/worker.c
+++ b/dsp/src/worker.c
@@ -123,7 +123,7 @@ void *geonkick_worker_thread(void *arg)
         while (geonkick_worker->running) {
 		/**
                  * Ignore too many updates.
-                 * The last udpates will be processed.
+                 * The last updates will be processed.
                  */
                 usleep(40000);
                 gkick_log_debug("process...");

--- a/src/ExportSoundData.cpp
+++ b/src/ExportSoundData.cpp
@@ -94,7 +94,7 @@ ExportSoundData::Subformat ExportSoundData::subformat() const
 
 void ExportSoundData::setSubformat(ExportSoundData::Subformat subFormat)
 {
-        if (!validateSubfromat(subFormat)) {
+        if (!validateSubformat(subFormat)) {
                 GEONKICK_LOG_ERROR("wrong subformat " << static_cast<int>(subFormat)
                                    << " for format "
                                    << static_cast<int>(format()));
@@ -123,7 +123,7 @@ void ExportSoundData::setNumberOfChannels(int channels)
         nChannels = channels;
 }
 
-bool ExportSoundData::validateSubfromat(Subformat subFormat)
+bool ExportSoundData::validateSubformat(Subformat subFormat)
 {
         switch (format()) {
         case ExportFormat::Flac:

--- a/src/ExportSoundData.h
+++ b/src/ExportSoundData.h
@@ -43,7 +43,7 @@ class ExportSoundData : public ExportAbstract {
                         ExportFormat exportFormat = ExportFormat::Flac);
         bool doExport() override;
         Subformat subformat() const;
-        void setSubformat(Subformat fromat);
+        void setSubformat(Subformat format);
         int getSampleRate() const;
         void setSmapleRate(int srate);
         int numberOfChannels() const;
@@ -51,7 +51,7 @@ class ExportSoundData : public ExportAbstract {
 
  protected:
         Subformat getDefaultSubformat() const;
-        bool validateSubfromat(Subformat subFormat);
+        bool validateSubformat(Subformat subFormat);
         int sfExportFormat() const;
 
  private:

--- a/src/envelope_widget.cpp
+++ b/src/envelope_widget.cpp
@@ -73,7 +73,7 @@ EnvelopeWidget::EnvelopeWidget(GeonkickWidget *parent,
         envelopes.insert({static_cast<int>(Envelope::Category::Noise), envelope});
         envelope->setCategory(Envelope::Category::Noise);
 
-        // General nevelope
+        // General envelope
         envelope = std::dynamic_pointer_cast<Envelope>(std::make_shared<GeneralEnvelope>(geonkickApi, rect));
         envelopes.insert({static_cast<int>(Envelope::Category::General), envelope});
         envelope->setCategory(Envelope::Category::General);

--- a/src/geonkick_checkbox.cpp
+++ b/src/geonkick_checkbox.cpp
@@ -71,9 +71,9 @@ void GeonkickCheckbox::setUncheckedImage(const std::string &file)
         setUncheckedImage(QPixmap(file));
 }
 
-void GeonkickCheckbox::setPadding(int left, int top, int right, int buttom)
+void GeonkickCheckbox::setPadding(int left, int top, int right, int bottom)
 {
-        mainLayout->setContentsMargins(left, top, right, buttom);
+        mainLayout->setContentsMargins(left, top, right, bottom);
 }
 
 void GeonkickCheckbox::setChecked(bool checked)

--- a/src/geonkick_checkbox.h
+++ b/src/geonkick_checkbox.h
@@ -38,7 +38,7 @@ class GeonkickCheckbox: public GeonkickWidget {
         void setUncheckedImage(const QPixmap &pixmap);
         void setCheckedImage(const std::string &file);
         void setUncheckedImage(const std::string &file);
-        void setPadding(int left, int top, int right, int buttom);
+        void setPadding(int left, int top, int right, int bottom);
         void setChecked(bool checked);
         void stateUpdated(bool state);
 

--- a/src/geonkick_groupbox.h
+++ b/src/geonkick_groupbox.h
@@ -42,7 +42,7 @@ class GeonkickGroupBox: public GeonkickWidget
      void setGroupBoxLabel(GeonkickWidget *label);
      GeonkickWidget* addWidget(GeonkickWidget *widget);
      void setWidgetAlignment(GeonkickWidget *widget);
-     void setPadding(int left, int top, int right, int buttom);
+     void setPadding(int left, int top, int right, int bottom);
 
  private:
      Orientation groupBoxOrientation;

--- a/src/kick_graph.cpp
+++ b/src/kick_graph.cpp
@@ -67,7 +67,7 @@ void KickGraph::updateGraphBuffer()
 void KickGraph::drawKickGraph()
 {
         while (isRunning) {
-                // Ignore too many updates. The last udpate will be processed.
+                // Ignore too many updates. The last update will be processed.
                 std::this_thread::sleep_for(std::chrono::milliseconds(60));
                 std::unique_lock<std::mutex> lock(graphMutex);
                 if (!updateGraph)

--- a/src/resources/resources.rc
+++ b/src/resources/resources.rc
@@ -250,7 +250,7 @@ ${GKICK_RC_DIR}/env_button_on_png.c
 ${GKICK_RC_DIR}/scrollbar_button_up_png.c
 ${GKICK_RC_DIR}/scrollbar_button_down_png.c
 
-# === Smaples Browser ===
+# === Samples Browser ===
 
 ${GKICK_RC_DIR}/play_preview_sample_png.c
 ${GKICK_RC_DIR}/play_preview_sample_hover_png.c


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rdparty,./redkite -L labeld,ned`